### PR TITLE
add commodity_leaf feature; separate reader from investment type; refactor

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,14 @@
+
+=================================
+beancount_reds_importers: CHANGES
+=================================
+
+2021-01-29
+
+ - added the commodity_leaf feature: by default, accounts will now include a commodity
+   as their leaf (eg: Assets:Investments:HOOLI). This is configurable. Simply pass in a
+   'commodity_leaf: False' in your importer config.
+
+ - the source reader (eg: ofx, csv, ...) has now been separated from the importer type
+   (eg: investment, banking, ...). This allows us easy combining of these.
+

--- a/beancount_reds_importers/example/my.import
+++ b/beancount_reds_importers/example/my.import
@@ -7,6 +7,7 @@ from os import path
 sys.path.insert(0, path.join(path.dirname(__file__)))
 
 from beancount_reds_importers import vanguard
+from beancount_reds_importers import schwab_csv
 from fund_info import *
 
 # Setting this variable provides a list of importer instances.
@@ -33,6 +34,18 @@ CONFIG = [
         'dividends'      : 'Income:Dividends:RothIRA',
         'cg'             : 'Income:Capital-Gains:RothIRA',
         'fees'           : 'Expenses:Brokerage-Fees:RothIRA',
+        'rounding_error' : 'Equity:Rounding-Errors:Imports',
+        'fund_info'       : fund_info,
+    }),
+
+    schwab_csv.Importer({
+        'main_account'   : 'Assets:Investments:Schwab',
+        'account_number' : '18181',
+        'transfer'       : 'Assets:Zero-Sum-Accounts:Transfers:Bank-Account',
+        'dividends'      : 'Income:Dividends:Schwab',
+        'income'         : 'Income:Interest:Schwab',
+        'cg'             : 'Income:Capital-Gains:Schwab',
+        'fees'           : 'Expenses:Brokerage-Fees:Schwab',
         'rounding_error' : 'Equity:Rounding-Errors:Imports',
         'fund_info'       : fund_info,
     }),

--- a/beancount_reds_importers/libimport/banking.py
+++ b/beancount_reds_importers/libimport/banking.py
@@ -8,6 +8,7 @@ from beancount.core import data
 from beancount.core import amount
 from beancount.ingest import importer
 
+
 class Importer(importer.ImporterProtocol):
     def __init__(self, config):
         self.config = config
@@ -53,7 +54,7 @@ class Importer(importer.ImporterProtocol):
         if not file.name.endswith('fx'):
             return False
         self.custom_init()
-        if not self.filename_identifier_substring in file.name:
+        if self.filename_identifier_substring not in file.name:
             return False
         self.initialize(file)
         return self.ofx_account is not None
@@ -87,7 +88,7 @@ class Importer(importer.ImporterProtocol):
 
             # Build transaction entry
             entry = data.Transaction(metadata, ot.date.date(), self.FLAG,
-                   None, ot.payee, data.EMPTY_SET, data.EMPTY_SET, [])
+                                     None, ot.payee, data.EMPTY_SET, data.EMPTY_SET, [])
             data.create_simple_posting(entry, config['main_account'], ot.amount, self.currency)
 
             # Commented out so smart_importer can fill this in
@@ -103,8 +104,8 @@ class Importer(importer.ImporterProtocol):
         date += datetime.timedelta(days=1)
         meta = data.new_metadata(file.name, next(counter))
         balance_entry = data.Balance(meta, date.date(), self.config['main_account'],
-                amount.Amount(self.ofx_account.statement.balance, self.currency),
-                None, None)
+                                     amount.Amount(self.ofx_account.statement.balance, self.currency),
+                                     None, None)
         new_entries.append(balance_entry)
 
         return(new_entries)

--- a/beancount_reds_importers/libimport/csvreader.py
+++ b/beancount_reds_importers/libimport/csvreader.py
@@ -9,8 +9,8 @@ from beancount.ingest import importer
 from beancount.core.number import D
 import petl as etl
 
-class Importer(importer.ImporterProtocol):
 
+class Importer(importer.ImporterProtocol):
     def initialize_reader(self, file):
         if not self.initialized_reader:
             # TODO: move to custom_init
@@ -19,7 +19,7 @@ class Importer(importer.ImporterProtocol):
             if self.reader_ready:
                 # TODO: move out elsewhere?
                 # self.currency = self.ofx_account.statement.currency.upper()
-                self.currency = 'USD' #TODO
+                self.currency = 'USD'  # TODO
                 self.includes_balances = False
             self.initialized_reader = True
             self.file_read_done = False
@@ -87,7 +87,6 @@ class Importer(importer.ImporterProtocol):
             self.file_read_done = True
 
     def get_transactions(self):
-        new_entries = []
         for ot in self.rdr.namedtuples():
             if self.skip_transaction(ot):
                 continue
@@ -102,4 +101,3 @@ class Importer(importer.ImporterProtocol):
     # TOOD: custom, overridable
     def skip_transaction(self, row):
         return row.type in self.skip_transaction_types
-

--- a/beancount_reds_importers/libimport/csvreader.py
+++ b/beancount_reds_importers/libimport/csvreader.py
@@ -1,0 +1,105 @@
+"""csv importer module for beancount to be used along with investment/banking/other importer modules in
+beancount_reds_importers."""
+
+import datetime
+import ntpath
+import re
+from os import path
+from beancount.ingest import importer
+from beancount.core.number import D
+import petl as etl
+
+class Importer(importer.ImporterProtocol):
+
+    def initialize_reader(self, file):
+        if not self.initialized_reader:
+            # TODO: move to custom_init
+            self.header = '"Transactions  for account ' + self.config.get('custom_header', '')
+            self.reader_ready = re.match(self.header, file.head())
+            if self.reader_ready:
+                # TODO: move out elsewhere?
+                # self.currency = self.ofx_account.statement.currency.upper()
+                self.currency = 'USD' #TODO
+                self.includes_balances = False
+            self.initialized_reader = True
+            self.file_read_done = False
+
+    # TODO: factor out into reader class
+    def identify(self, file):
+        # quick check to filter out files that are not the right format
+        if not file.name.lower().endswith('csv'):
+            return False
+        self.custom_init()
+        if self.filename_identifier_substring not in path.basename(file.name):
+            return False
+        self.initialize_reader(file)
+        return self.reader_ready
+
+    def file_name(self, file):
+        return 'account-{}'.format(ntpath.basename(file.name))
+
+    def file_account(self, _):
+        return self.config['main_account']
+
+    def file_date(self, file):
+        "Get the maximum date from the file."
+        self.read_file(file)
+        return max(ot.date for ot in self.get_transactions()).date()
+
+    def prepare_raw_columns(self, rdr):
+        return rdr
+
+    def convert_columns(self, rdr):
+        # convert data in transaction types column
+        rdr = rdr.convert('type', self.transaction_type_map)
+
+        # fixup decimals
+        decimals = ['units']
+        for i in decimals:
+            rdr = rdr.convert(i, D)
+
+        # fixup currencies
+        def remove_non_numeric(x):
+            return re.sub("[^0-9\.]", "", x)
+        currencies = ['unit_price', 'fees', 'total', 'amount']
+        for i in currencies:
+            rdr = rdr.convert(i, remove_non_numeric)
+            rdr = rdr.convert(i, D)
+
+        # fixup dates
+        def convert_date(d):
+            return datetime.datetime.strptime(d, '%m/%d/%Y')
+        dates = ['date', 'tradeDate']
+        for i in dates:
+            rdr = rdr.convert(i, convert_date)
+
+        return rdr
+
+    def read_file(self, file):
+        if not self.file_read_done:
+            rdr = etl.fromcsv(file.name)
+            rdr = rdr.skip(self.skip_head_rows)
+            rdr = rdr.head(len(rdr) - self.skip_tail_rows - 1)
+            rdr = self.prepare_raw_columns(rdr)
+            rdr = rdr.rename(self.header_map)
+            rdr = self.convert_columns(rdr)
+            self.rdr = rdr
+            self.file_read_done = True
+
+    def get_transactions(self):
+        new_entries = []
+        for ot in self.rdr.namedtuples():
+            if self.skip_transaction(ot):
+                continue
+            yield ot
+
+    def get_balance_positions(self):
+        raise "Not supported"
+
+    def get_available_cash(self):
+        raise "Not supported"
+
+    # TOOD: custom, overridable
+    def skip_transaction(self, row):
+        return row.type in self.skip_transaction_types
+

--- a/beancount_reds_importers/libimport/investments.py
+++ b/beancount_reds_importers/libimport/investments.py
@@ -121,9 +121,9 @@ class Importer(importer.ImporterProtocol):
             metadata['todo'] = 'TODO: this entry is incomplete until lots are selected (bean-doctor context <filename> <lineno>)'
         units = ot.units
         total = ot.total
-        if 'sell' in ot.type or ot.type in ['reinvest']:
+        if 'sell' in ot.type:
             units = -1 * abs(ot.units)
-        description = f'{ot.type}: [{ticker}] {ticker_long_name}'
+        description = f'[{ticker}] {ticker_long_name}'
         target_acct = self.get_target_acct(ot)
         if ot.type in ['reinvest']:
             target_acct = self.commodity_leaf(target_acct, ticker)
@@ -191,9 +191,7 @@ class Importer(importer.ImporterProtocol):
 
         if ot.type in ['income', 'dividends']:
             ticker, ticker_long_name = self.get_ticker_info(ot.security)
-            description = f'{ot.type}: [{ticker}] {ticker_long_name}'
-
-        if ot.type in ['dividends']:
+            description = f'[{ticker}] {ticker_long_name}'
             target_acct = self.commodity_leaf(target_acct, ticker)
         else:  # cash transfer
             description = ot.type

--- a/beancount_reds_importers/libimport/investments.py
+++ b/beancount_reds_importers/libimport/investments.py
@@ -169,7 +169,7 @@ class Importer(importer.ImporterProtocol):
         return entry
 
     def generate_transfer_entry(self, ot, file, counter):
-        """ Cash or in-kind transfers. One of: ['other', 'credit', 'debit', 'transfer', 'dep', 'income', 'dividends']"""
+        """ Cash or in-kind transfers. One of: [credit, debit, dep, transfer, income, dividends, other]"""
         config = self.config
         # Build metadata
         metadata = data.new_metadata(file.name, next(counter))
@@ -182,7 +182,7 @@ class Importer(importer.ImporterProtocol):
         try:
             if ot.type in ['transfer']:
                 units = ot.units
-            elif ot.type in ['other', 'credit', 'debit']:
+            elif ot.type in ['other', 'credit', 'debit', 'dep']:
                 units = ot.amount
             else:
                 units = ot.total

--- a/beancount_reds_importers/libimport/investments.py
+++ b/beancount_reds_importers/libimport/investments.py
@@ -189,10 +189,11 @@ class Importer(importer.ImporterProtocol):
         except:
             import pdb; pdb.set_trace()
 
-        if ot.type in ['income', 'dividends']:
+        if ot.type in ['income', 'dividends'] or (hasattr(ot, 'security') and ot.security):
             ticker, ticker_long_name = self.get_ticker_info(ot.security)
             description = f'[{ticker}] {ticker_long_name}'
-            target_acct = self.commodity_leaf(target_acct, ticker)
+            if ot.type in ['income', 'dividends']: # no need to do this for transfers
+                target_acct = self.commodity_leaf(target_acct, ticker)
         else:  # cash transfer
             description = ot.type
             ticker = self.currency

--- a/beancount_reds_importers/libimport/investments.py
+++ b/beancount_reds_importers/libimport/investments.py
@@ -125,10 +125,10 @@ class Importer(importer.ImporterProtocol):
             units = -1 * abs(ot.units)
         description = f'[{ticker}] {ticker_long_name}'
         target_acct = self.get_target_acct(ot)
-        if ot.type in ['reinvest']:
+        if ot.type in ['reinvest']: # dividends are booked to commodity_leaf. Eg: Income:Dividends:HOOLI
             target_acct = self.commodity_leaf(target_acct, ticker)
         else:
-            target_acct += f':{self.currency}'
+            target_acct = self.commodity_leaf(target_acct, self.currency)
 
         # Build transaction entry
         entry = data.Transaction(metadata, ot.tradeDate.date(), self.FLAG,

--- a/beancount_reds_importers/libimport/investments.py
+++ b/beancount_reds_importers/libimport/investments.py
@@ -189,7 +189,7 @@ class Importer(importer.ImporterProtocol):
         except:
             import pdb; pdb.set_trace()
 
-        if ot.type in ['income', 'dividends'] or (hasattr(ot, 'security') and ot.security):
+        if ot.type in ['income', 'dividends', 'transfer'] and (hasattr(ot, 'security') and ot.security):
             ticker, ticker_long_name = self.get_ticker_info(ot.security)
             description = f'[{ticker}] {ticker_long_name}'
             if ot.type in ['income', 'dividends']: # no need to do this for transfers

--- a/beancount_reds_importers/libimport/ofx.py
+++ b/beancount_reds_importers/libimport/ofx.py
@@ -23,8 +23,10 @@ class Importer(importer.ImporterProtocol):
                 # account identifying info fieldname varies across institutions
                 if getattr(acc, self.account_number_field) == self.config['account_number']:
                     self.ofx_account = acc
-            if self.ofx_account is not None:
+                    self.reader_ready = True
+            if self.reader_ready:
                 self.currency = self.ofx_account.statement.currency.upper()
+                self.includes_balances = True
             self.initialized_reader = True
 
     def identify(self, file):
@@ -50,3 +52,7 @@ class Importer(importer.ImporterProtocol):
     def get_transactions(self):
         for ot in self.ofx_account.statement.transactions:
             yield ot
+
+    def get_balance_positions(self):
+        for pos in self.ofx_account.statement.positions:
+            yield pos

--- a/beancount_reds_importers/libimport/ofx.py
+++ b/beancount_reds_importers/libimport/ofx.py
@@ -56,3 +56,6 @@ class Importer(importer.ImporterProtocol):
     def get_balance_positions(self):
         for pos in self.ofx_account.statement.positions:
             yield pos
+
+    def get_available_cash(self):
+        return self.ofx_account.statement.available_cash

--- a/beancount_reds_importers/libimport/ofx.py
+++ b/beancount_reds_importers/libimport/ofx.py
@@ -1,0 +1,52 @@
+"""Ofx importer module for beancount to be used along with investment/banking/other importer modules in
+beancount_reds_importers."""
+
+import datetime
+import itertools
+import ntpath
+import sys
+import traceback
+from ofxparse import OfxParser
+from beancount.core import data
+from beancount.core import amount
+from beancount.ingest import importer
+from beancount.core.position import CostSpec
+from beancount_reds_importers.libimport import common
+
+class Importer(importer.ImporterProtocol):
+
+    def initialize_reader(self, file):
+        if not self.initialized_reader:
+            self.ofx = OfxParser.parse(open(file.name))
+            self.ofx_account = None
+            for acc in self.ofx.accounts:
+                # account identifying info fieldname varies across institutions
+                if getattr(acc, self.account_number_field) == self.config['account_number']:
+                    self.ofx_account = acc
+            if self.ofx_account is not None:
+                self.currency = self.ofx_account.statement.currency.upper()
+            self.initialized_reader = True
+
+    def identify(self, file):
+        # quick check to filter out files that are not qfx/ofx
+        if not file.name.endswith('fx'):
+            return False
+        self.custom_init()
+        if self.filename_identifier_substring not in file.name:
+            return False
+        self.initialize(file)
+        return self.ofx_account is not None
+
+    def file_name(self, file):
+        return 'account-{}'.format(ntpath.basename(file.name))
+
+    def file_account(self, _):
+        return self.config['main_account']
+
+    def file_date(self, file):
+        "Get the maximum date from the file."
+        self.ofx_account.statement.end_date
+
+    def get_transactions(self):
+        for ot in self.ofx_account.statement.transactions:
+            yield ot

--- a/beancount_reds_importers/libimport/ofxreader.py
+++ b/beancount_reds_importers/libimport/ofxreader.py
@@ -5,8 +5,8 @@ import ntpath
 from beancount.ingest import importer
 from ofxparse import OfxParser
 
-class Importer(importer.ImporterProtocol):
 
+class Importer(importer.ImporterProtocol):
     def initialize_reader(self, file):
         if not self.initialized_reader:
             self.ofx = OfxParser.parse(open(file.name))

--- a/beancount_reds_importers/libimport/ofxreader.py
+++ b/beancount_reds_importers/libimport/ofxreader.py
@@ -1,17 +1,9 @@
 """Ofx importer module for beancount to be used along with investment/banking/other importer modules in
 beancount_reds_importers."""
 
-import datetime
-import itertools
 import ntpath
-import sys
-import traceback
-from ofxparse import OfxParser
-from beancount.core import data
-from beancount.core import amount
 from beancount.ingest import importer
-from beancount.core.position import CostSpec
-from beancount_reds_importers.libimport import common
+from ofxparse import OfxParser
 
 class Importer(importer.ImporterProtocol):
 
@@ -31,13 +23,13 @@ class Importer(importer.ImporterProtocol):
 
     def identify(self, file):
         # quick check to filter out files that are not qfx/ofx
-        if not file.name.endswith('fx'):
+        if not file.name.lower().endswith('fx'):
             return False
         self.custom_init()
         if self.filename_identifier_substring not in file.name:
             return False
-        self.initialize(file)
-        return self.ofx_account is not None
+        self.initialize_reader(file)
+        return self.reader_ready
 
     def file_name(self, file):
         return 'account-{}'.format(ntpath.basename(file.name))
@@ -48,6 +40,9 @@ class Importer(importer.ImporterProtocol):
     def file_date(self, file):
         "Get the maximum date from the file."
         self.ofx_account.statement.end_date
+
+    def read_file(self, file):
+        pass
 
     def get_transactions(self):
         for ot in self.ofx_account.statement.transactions:

--- a/beancount_reds_importers/schwab/__init__.py
+++ b/beancount_reds_importers/schwab/__init__.py
@@ -2,9 +2,10 @@
 
 import ntpath
 import beancount_reds_importers.libimport.investments
+import beancount_reds_importers.libimport.ofxreader
 
-
-class Importer(beancount_reds_importers.libimport.investments.Importer):
+class Importer(beancount_reds_importers.libimport.investments.Importer,
+        beancount_reds_importers.libimport.ofxreader.Importer):
     def custom_init(self):
         self.max_rounding_error = 0.04
         self.account_number_field = 'number'

--- a/beancount_reds_importers/schwab_csv/__init__.py
+++ b/beancount_reds_importers/schwab_csv/__init__.py
@@ -1,0 +1,52 @@
+""" Schwab csv importer."""
+
+import sys
+import ntpath
+import beancount_reds_importers.libimport.investments
+import beancount_reds_importers.libimport.csvreader
+
+class Importer(beancount_reds_importers.libimport.investments.Importer,
+        beancount_reds_importers.libimport.csvreader.Importer):
+
+    def custom_init(self):
+        self.max_rounding_error = 0.04
+        self.account_number_field = 'number'
+        self.filename_identifier_substring = '_Transactions_'
+        self.get_ticker_info = self.get_ticker_info_from_id
+        self.date_format = '%m/%d/%Y'
+        self.skip_head_rows = 1
+        self.skip_tail_rows = 1
+        self.funds_db_txt = 'funds_by_ticker'
+        self.header_map = {
+            "Action":      'type',
+            "Date":        'date',
+            "tradeDate":   'tradeDate',
+            "Description": 'memo',
+            "Symbol":      'security',
+            "Quantity":    'units',
+            "Price":       'unit_price',
+            "Amount":      'amount',
+            "total":       'total',
+            "Fees & Comm": 'fees',
+            }
+        self.transaction_type_map = {
+            'Bank Interest':      'income',
+            'Buy':                'buystock',
+            'Cash Dividend':      'dividends',
+            'MoneyLink Transfer': 'transfer',
+            'Reinvest Dividend':  'dividends',
+            'Reinvest Shares':    'buystock',
+            'Sell':               'sellstock',
+            }
+        self.skip_transaction_types = ['Journal']
+
+    def prepare_raw_columns(self, rdr):
+        rdr = rdr.cutout('') # clean up last column
+
+        def cleanup_date(d):
+            """'11/16/2018 as of 11/15/2018' --> '11/16/2018'"""
+            return d.split(' ', 1)[0]
+        rdr = rdr.convert('Date', cleanup_date)
+        rdr = rdr.addfield('tradeDate', lambda x: x['Date'])
+        rdr = rdr.addfield('total', lambda x: x['Amount'])
+        return rdr

--- a/beancount_reds_importers/vanguard/__init__.py
+++ b/beancount_reds_importers/vanguard/__init__.py
@@ -15,3 +15,9 @@ class Importer(beancount_reds_importers.libimport.investments.Importer,
 
     def file_name(self, file):
         return 'vanguard-all-{}'.format(ntpath.basename(file.name))
+
+    def get_target_acct(self, transaction):
+        m = transaction.memo
+        if 'DIVIDEND' in m:
+            return self.config['dividends']
+        return self.target_account_map.get(transaction.type, None)

--- a/beancount_reds_importers/vanguard/__init__.py
+++ b/beancount_reds_importers/vanguard/__init__.py
@@ -3,9 +3,11 @@
 import sys
 import ntpath
 import beancount_reds_importers.libimport.investments
+import beancount_reds_importers.libimport.ofx
 
 
-class Importer(beancount_reds_importers.libimport.investments.Importer):
+class Importer(beancount_reds_importers.libimport.investments.Importer,
+        beancount_reds_importers.libimport.ofx.Importer):
     def custom_init(self):
         self.max_rounding_error = 0.04
         self.account_number_field = 'number'

--- a/beancount_reds_importers/vanguard/__init__.py
+++ b/beancount_reds_importers/vanguard/__init__.py
@@ -16,8 +16,5 @@ class Importer(beancount_reds_importers.libimport.investments.Importer,
     def file_name(self, file):
         return 'vanguard-all-{}'.format(ntpath.basename(file.name))
 
-    def get_target_acct(self, transaction):
-        m = transaction.memo
-        if 'DIVIDEND' in m:
-            return self.config['dividends']
+    def get_target_acct_custom(self, transaction):
         return self.target_account_map.get(transaction.type, None)

--- a/beancount_reds_importers/vanguard/__init__.py
+++ b/beancount_reds_importers/vanguard/__init__.py
@@ -3,11 +3,11 @@
 import sys
 import ntpath
 import beancount_reds_importers.libimport.investments
-import beancount_reds_importers.libimport.ofx
+import beancount_reds_importers.libimport.ofxreader
 
 
 class Importer(beancount_reds_importers.libimport.investments.Importer,
-        beancount_reds_importers.libimport.ofx.Importer):
+        beancount_reds_importers.libimport.ofxreader.Importer):
     def custom_init(self):
         self.max_rounding_error = 0.04
         self.account_number_field = 'number'

--- a/beancount_reds_importers/vanguard/__init__.py
+++ b/beancount_reds_importers/vanguard/__init__.py
@@ -5,7 +5,6 @@ import ntpath
 import beancount_reds_importers.libimport.investments
 import beancount_reds_importers.libimport.ofxreader
 
-
 class Importer(beancount_reds_importers.libimport.investments.Importer,
         beancount_reds_importers.libimport.ofxreader.Importer):
     def custom_init(self):


### PR DESCRIPTION
 - added the commodity_leaf feature: by default, accounts will now include a commodity
   as their leaf (eg: Assets:Investments:HOOLI). This is configurable. Simply pass in a
   'commodity_leaf: False' in your importer config.

 - the source reader (eg: ofx, csv, ...) has now been separated from the importer type
   (eg: investment, banking, ...). This allows us easy combining of these.