### PR TITLE
Edit get_security_list() to not filter to handle CUSIPs without trans…

### DIFF
--- a/beancount_reds_importers/libtransactionbuilder/investments.py
+++ b/beancount_reds_importers/libtransactionbuilder/investments.py
@@ -96,8 +96,7 @@ class Importer(importer.ImporterProtocol):
     def get_security_list(self):
         tickers = set()
         for ot in self.get_transactions():
-            if ot.type in ['buymf', 'sellmf', 'buystock', 'sellstock', 'reinvest', 'income']:
-                tickers.add(ot.security)
+            tickers.add(ot.security)
         return tickers
 
     def commodity_leaf(self, account, ticker):


### PR DESCRIPTION
…actions.

Had an issue with a vanguard qfx file where I was getting an error of 
"Error: fund info not found for: []" 
where the missing fund wasn't getting shown, thus not found in get_security_list. It turned out there was a line in the qfx file where there was no event of 'buymf', 'sellmf', 'buystock', 'sellstock', 'reinvest', but either a 'mfinfo' event such as:

```<MFINFO><SECINFO><SECID><UNIQUEID>999999999<UNIQUEIDTYPE>CUSIP</SECID><SECNAME>WORLD BLAH  ETF<TICKER>BLAH<UNITPRICE>99.999<MEMO>Price as of date based on closing price</SECINFO><MFTYPE>```

or 'posmf' events:

```<POSMF><INVPOS><SECID><UNIQUEID>999999999<UNIQUEIDTYPE>CUSIP</SECID><HELDINACCT>CASH<POSTYPE>LONG<UNITS>100.0<UNITPRICE>99.999<MKTVAL>9999.99<DTPRICEASOF>20210420160000.000[-5:EST]<MEMO>Price as of date based on closing price</INVPOS><REINVDIV>N<REINVCG>N</POSMF>```

I tried changing things to be filter including posmf/mfinfo events i.e. "if ot.type in ['mfinfo', 'posmf', 'buymf', 'sellmf', 'buystock', 'sellstock', 'reinvest', 'income']:" but wasn't working at all. Found just removing the line will at least cause a more descriptive error to help me figure out what fund_info to add like "KeyError: '999999999'" instead.