### PR TITLE
Fix handling for readers when available_cash is not present.

### DIFF
--- a/beancount_reds_importers/libreader/csv_multitable_reader.py
+++ b/beancount_reds_importers/libreader/csv_multitable_reader.py
@@ -102,4 +102,4 @@ class Importer(csvreader.Importer):
         raise "Not supported"
 
     def get_available_cash(self):
-        return False
+        return None

--- a/beancount_reds_importers/libreader/csvreader.py
+++ b/beancount_reds_importers/libreader/csvreader.py
@@ -131,7 +131,7 @@ class Importer(reader.Reader, importer.ImporterProtocol):
         raise "Not supported"
 
     def get_available_cash(self):
-        raise "Not supported"
+        return None
 
     # TOOD: custom, overridable
     def skip_transaction(self, row):

--- a/beancount_reds_importers/libreader/ofxreader.py
+++ b/beancount_reds_importers/libreader/ofxreader.py
@@ -56,7 +56,7 @@ class Importer(reader.Reader, importer.ImporterProtocol):
             yield pos
 
     def get_available_cash(self):
-        return self.ofx_account.statement.available_cash
+        return getattr(self.ofx_account.statement, 'available_cash', None)
 
     def get_max_transaction_date(self):
         try:

--- a/beancount_reds_importers/libtransactionbuilder/investments.py
+++ b/beancount_reds_importers/libtransactionbuilder/investments.py
@@ -296,17 +296,14 @@ class Importer(importer.ImporterProtocol):
 
         # ----------------- available cash
         available_cash = self.get_available_cash()
-        if available_cash is not False:
-            try:
-                balance = self.get_available_cash() - settlement_fund_balance
-                meta = data.new_metadata(file.name, next(counter))
-                bal_date = date if date else self.file_date(file).date()
-                balance_entry = data.Balance(meta, bal_date, self.cash_account,
-                                             amount.Amount(balance, self.currency),
-                                             None, None)
-                new_entries.append(balance_entry)
-            except AttributeError:  # self.get_available_cash()
-                pass
+        if available_cash is not None:
+            balance = available_cash - settlement_fund_balance
+            meta = data.new_metadata(file.name, next(counter))
+            bal_date = date if date else self.file_date(file).date()
+            balance_entry = data.Balance(meta, bal_date, self.cash_account,
+                                         amount.Amount(balance, self.currency),
+                                         None, None)
+            new_entries.append(balance_entry)
 
         return new_entries
 


### PR DESCRIPTION
This is required for current Vanguard retirement OFX files.