### PR TITLE
Don't sort paycheck postings so that related postings are next to each other

### DIFF
--- a/beancount_reds_importers/libtransactionbuilder/paycheck.py
+++ b/beancount_reds_importers/libtransactionbuilder/paycheck.py
@@ -82,7 +82,12 @@ class Importer(banking.Importer):
                             data.create_simple_posting(entry, account, amount, currency)
         if total != 0:
             data.create_simple_posting(entry, "TOTAL:NONZERO", total, currency)
-        newentry = entry._replace(postings=sorted(entry.postings))
+
+        if self.config.get('sort_postings', True):
+            postings = sorted(entry.postings)
+        else:
+            postings = entry.postings
+        newentry = entry._replace(postings=postings)
         return newentry
 
     def extract(self, file, existing_entries=None):


### PR DESCRIPTION
For example, with a configuration containing a template such as:

```
'Employer Paid Benefits': {
    '401(k) Employer Match': [
	'Income:Hooli:Benefits:401k-Match',
	'Assets:Hooli-401k-Match',
    ],
    ...
 ```

It's helpful if the generated beancount transaction includes the `Income:Hooli:Benefits:401k-Match` and `Assets:Hooli-401k-Match` postings on consecutive lines rather than intermixed with postings from other paycheck line items.