### PR TITLE
Convert value to str before applying regex in remove_non_numeric

### DIFF
--- a/beancount_reds_importers/libreader/csvreader.py
+++ b/beancount_reds_importers/libreader/csvreader.py
@@ -95,7 +95,7 @@ class Importer(reader.Reader, importer.ImporterProtocol):
 
         # fixup currencies
         def remove_non_numeric(x):
-            return re.sub("[^0-9\.-]", "", x.strip())  # noqa: W605
+            return re.sub("[^0-9\.-]", "", str(x).strip())  # noqa: W605
         currencies = ['unit_price', 'fees', 'total', 'amount']
         for i in currencies:
             if i in rdr.header():


### PR DESCRIPTION
If the type of `x` is not a string, but rather a float or an int, calling `strip()` on it will fail and the returned value will always be an empty string.

I've faced this issue when I've imported an xlsx file using `xlsxreader` where the the amount and the currency were in separate fields and the amount field was returned as a float.