### PR TITLE
Better missing security reporting

### DIFF
--- a/beancount_reds_importers/libtransactionbuilder/investments.py
+++ b/beancount_reds_importers/libtransactionbuilder/investments.py
@@ -129,7 +129,17 @@ class Importer(importer.ImporterProtocol):
                     if s in k:
                         securities_missing.remove(s)
             # securities_missing = [s for s in securities if s not in self.funds_db]
-            print(f"List of securities without fund info: {securities_missing}", file=sys.stderr)
+            # try to extract security info from ofx
+            ofx_securities = dict()
+            try:
+                for o in self.ofx.security_list:
+                    ofx_securities[o.ticker] = o.name
+            except AttributeError:
+                # ofx doesn't have a security list
+                pass
+            for m in securities_missing:
+                print(f"%s: %s" % (m, ofx_securities.get(m, "???")), file=sys.stderr)
+            # print(f"List of securities without fund info: {securities_missing}", file=sys.stderr)
             # import pdb; pdb.set_trace()
             sys.exit(1)
         return ticker, ticker_long_name

--- a/beancount_reds_importers/libtransactionbuilder/investments.py
+++ b/beancount_reds_importers/libtransactionbuilder/investments.py
@@ -151,7 +151,7 @@ class Importer(importer.ImporterProtocol):
                 # ofx doesn't have a security list
                 pass
 
-            print(f"List of securities without fund info:", file=sys.stderr)
+            print("List of securities without fund info:", file=sys.stderr)
             for m in securities_missing:
                 print("%s: %s" % (m, ofx_securities.get(m, "???")), file=sys.stderr)
             # print(f"List of securities without fund info: {securities_missing}", file=sys.stderr)

--- a/beancount_reds_importers/libtransactionbuilder/investments.py
+++ b/beancount_reds_importers/libtransactionbuilder/investments.py
@@ -129,11 +129,24 @@ class Importer(importer.ImporterProtocol):
                     if s in k:
                         securities_missing.remove(s)
             # securities_missing = [s for s in securities if s not in self.funds_db]
+
             # try to extract security info from ofx
             ofx_securities = dict()
             try:
                 for o in self.ofx.security_list:
-                    ofx_securities[o.ticker] = o.name
+                    # It seems that because of the way investment transactions are reported
+                    # in ofx the securities returned by self.get_security_list() are a list
+                    # of cusip codes.  In the section of the ofx that lists all securities
+                    # and is found in self.ofx.security_list these codes are generally
+                    # referred to as UNIQUEID (though the presence of another key called
+                    # UNIQUEIDTYPE suggests that UNIQUEID is not always a cusip).
+                    # because of this the key for the ofx_securities dict is uniqueid which
+                    # corresponds to the items in the securities_missing list.  The values
+                    # of this dict are the best guess at what an entry for fund_info.py should
+                    # be: a tuple of (ticker, cusip, name).  Note in the case of bonds the
+                    # ticker will match the cusip (at least in examples I have) and not be
+                    # literally usable as a beancount symbol
+                    ofx_securities[o.uniqueid] = (o.ticker, o.uniqueid, o.name)
             except AttributeError:
                 # ofx doesn't have a security list
                 pass

--- a/beancount_reds_importers/libtransactionbuilder/investments.py
+++ b/beancount_reds_importers/libtransactionbuilder/investments.py
@@ -137,6 +137,8 @@ class Importer(importer.ImporterProtocol):
             except AttributeError:
                 # ofx doesn't have a security list
                 pass
+
+            print(f"List of securities without fund info:", file=sys.stderr)
             for m in securities_missing:
                 print(f"%s: %s" % (m, ofx_securities.get(m, "???")), file=sys.stderr)
             # print(f"List of securities without fund info: {securities_missing}", file=sys.stderr)

--- a/beancount_reds_importers/libtransactionbuilder/investments.py
+++ b/beancount_reds_importers/libtransactionbuilder/investments.py
@@ -140,7 +140,7 @@ class Importer(importer.ImporterProtocol):
 
             print(f"List of securities without fund info:", file=sys.stderr)
             for m in securities_missing:
-                print(f"%s: %s" % (m, ofx_securities.get(m, "???")), file=sys.stderr)
+                print("%s: %s" % (m, ofx_securities.get(m, "???")), file=sys.stderr)
             # print(f"List of securities without fund info: {securities_missing}", file=sys.stderr)
             # import pdb; pdb.set_trace()
             sys.exit(1)


### PR DESCRIPTION
If `get_ticker_info_from_id` finds a missing `security_id` try to use a `security_list` in the ofx itself to print out useful information.

Fidelity ofx files appear to have a full security list embedded, and in most (all?) cases this is all that is needed to update `fund_info.py`.  All that this does is print out a list of the symbols (as is already done) and the `name` provided in the ofx.

If `security_list` is missing from the ofx the behavior should be no worse than today...print a list of missing symbols.