### PR TITLE
when matching ofx security_id to funds_db prefer a complete match

### DIFF
--- a/beancount_reds_importers/libtransactionbuilder/investments.py
+++ b/beancount_reds_importers/libtransactionbuilder/investments.py
@@ -119,7 +119,11 @@ class Importer(importer.ImporterProtocol):
     def get_ticker_info_from_id(self, security_id):
         try:
             # isin might look like "US293409829" while the ofx use only a substring like "29340982"
-            ticker, ticker_long_name = [v for k, v in self.funds_db.items() if security_id in k][0]
+            # first try a full match, fall back to substring
+            ticker = None
+            ticker, ticker_long_name = [v for k, v in self.funds_db.items() if security_id == k][0]
+            if ticker is None:
+                ticker, ticker_long_name = [v for k, v in self.funds_db.items() if security_id in k][0]
         except IndexError:
             print(f"Error: fund info not found for {security_id}", file=sys.stderr)
             securities = self.get_security_list()


### PR DESCRIPTION
I have found a couple of instances where one `security_id` in an OFX is a substring of another `security_id` that I have in my `fund_info.py` file.  This change first tries to do a full match, and if nothing is found falls back to the current behavior of matching on a substring.