### PR TITLE
Importer.extract: Explicitly name args to Transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,16 @@ File format readers included are:
 - `.xlsx` (single and multitable support)
 
 Transaction builders included are:
-- banking (for banks and credit cards, which benefit from a postings predictor like
-  [smart_importer](https://github.com/beancount/smart_importer)
-- investments/brokerages (to handle the very many distinct cases of investment related
-  transactions)
-- paychecks (to handle paychecks, which typically contain very many mostly
-  pre-determined postings in a single entry)
+- Banking (for banks and credit cards, which benefit from a postings predictor like
+  [smart_importer](https://github.com/beancount/smart_importer).  Note that,
+  depending on the institution, the `payee` and `narration` fields in generated
+  transactions may appear to be switched. This is described by
+  [libtransactionbuilder/banking.py](https://github.com/redstreet/beancount_reds_importers/blob/main/beancount_reds_importers/libtransactionbuilder/banking.py).
+  and the fields can be swapped in a `custom_init`.
+- Investments/brokerages (to handle the very many distinct cases of investment related
+  transactions).
+- Paychecks (to handle paychecks, which typically contain very many mostly
+  pre-determined postings in a single entry).
 
 [Input in `.ofx` format (over `.csv`) is preferred](https://reds-rants.netlify.app/personal-finance/a-word-about-input-formats-use-ofx-when-you-can/),
 when provided by the institution, as it minimizes data and coding errors, eliminates

--- a/beancount_reds_importers/libtransactionbuilder/banking.py
+++ b/beancount_reds_importers/libtransactionbuilder/banking.py
@@ -124,9 +124,16 @@ class Importer(importer.ImporterProtocol):
             # Build transaction entry
             # Banking transactions might include foreign currency transactions. TODO: figure out
             # how ofx handles this and use the same interface for csv and other files
-            entry = data.Transaction(metadata, ot.date.date(), self.FLAG,
-                                     self.get_narration(ot), self.get_payee(ot),
-                                     data.EMPTY_SET, data.EMPTY_SET, [])
+            entry = data.Transaction(
+                    meta=metadata,
+                    date=ot.date.date(),
+                    flag=self.FLAG,
+                    # payee and narration are switched. See the preceding note
+                    payee=self.get_narration(ot),
+                    narration=self.get_payee(ot),
+                    tags=data.EMPTY_SET,
+                    links=data.EMPTY_SET,
+                    postings=[])
 
             main_account = self.get_main_account(ot)
 


### PR DESCRIPTION
This shows that payee and narration are switched, as documented. https://github.com/beancount/beancount/blob/v2/beancount/core/data.py is the reference. This confused my use of smart_importer completion from an existing ledger and took me some time to figure out.

I think the arguments should be swithed but I can see this would be difficult to do while maintaining backwards compatibility.