### PR TITLE
refactor: call read_file() to allow override

### DIFF
--- a/beancount_reds_importers/libreader/ofxreader.py
+++ b/beancount_reds_importers/libreader/ofxreader.py
@@ -17,7 +17,7 @@ class Importer(reader.Reader, importer.ImporterProtocol):
             self.ofx_account = None
             self.reader_ready = False
             try:
-                self.ofx = ofxparse.OfxParser.parse(open(file.name))
+                self.ofx = self.read_file(file)
             except ofxparse.OfxParserException:
                 return
             for acc in self.ofx.accounts:
@@ -46,7 +46,8 @@ class Importer(reader.Reader, importer.ImporterProtocol):
             return None
 
     def read_file(self, file):
-        pass
+        with open(file.name) as fh:
+            return ofxparse.OfxParser.parse(fh)
 
     def get_transactions(self):
         yield from self.ofx_account.statement.transactions


### PR DESCRIPTION
Refactor ofxreader to call its read_file() method when parsing an ofx file.  This allows subclasses to override it and do pre/post processing on the ofx file.

In my case, it allows me to preprocess (fix) a very badly formatted ofx file that OfxParser was unable to read.