### PR TITLE
feat: add get_tags to transactionbuilders

### DIFF
--- a/beancount_reds_importers/libtransactionbuilder/banking.py
+++ b/beancount_reds_importers/libtransactionbuilder/banking.py
@@ -73,6 +73,10 @@ class Importer(importer.ImporterProtocol):
     def get_target_account(self, ot):
         """Can be overridden by importer"""
         return self.config.get('target_account')
+    
+    def get_tags(self, ot):
+        """Can be overridden by importer"""
+        return data.EMPTY_SET
 
     # --------------------------------------------------------------------------------
 
@@ -135,7 +139,7 @@ class Importer(importer.ImporterProtocol):
                     # payee and narration are switched. See the preceding note
                     payee=self.get_narration(ot),
                     narration=self.get_payee(ot),
-                    tags=data.EMPTY_SET,
+                    tags=self.get_tags(ot),
                     links=data.EMPTY_SET,
                     postings=[])
 

--- a/beancount_reds_importers/libtransactionbuilder/banking.py
+++ b/beancount_reds_importers/libtransactionbuilder/banking.py
@@ -73,8 +73,8 @@ class Importer(importer.ImporterProtocol):
     def get_target_account(self, ot):
         """Can be overridden by importer"""
         return self.config.get('target_account')
-    
-    def get_tags(self, ot):
+
+    def get_tags(self, ot=None):
         """Can be overridden by importer"""
         return data.EMPTY_SET
 

--- a/beancount_reds_importers/libtransactionbuilder/investments.py
+++ b/beancount_reds_importers/libtransactionbuilder/investments.py
@@ -183,10 +183,10 @@ class Importer(importer.ImporterProtocol):
     def skip_transaction(self, ot):
         return False
 
-    def get_tags(self, ot):
+    def get_tags(self, ot=None):
         """Can be overridden by importer"""
         return data.EMPTY_SET
-    
+
     # extract() and supporting methods
     # --------------------------------------------------------------------------------
 

--- a/beancount_reds_importers/libtransactionbuilder/investments.py
+++ b/beancount_reds_importers/libtransactionbuilder/investments.py
@@ -183,6 +183,10 @@ class Importer(importer.ImporterProtocol):
     def skip_transaction(self, ot):
         return False
 
+    def get_tags(self, ot):
+        """Can be overridden by importer"""
+        return data.EMPTY_SET
+    
     # extract() and supporting methods
     # --------------------------------------------------------------------------------
 
@@ -218,7 +222,7 @@ class Importer(importer.ImporterProtocol):
         # Build transaction entry
         entry = data.Transaction(metadata, ot.tradeDate.date(), self.FLAG,
                                  self.get_payee(ot), narration,
-                                 data.EMPTY_SET, data.EMPTY_SET, [])
+                                 self.get_tags(ot), data.EMPTY_SET, [])
 
         # Main posting(s):
         main_acct = self.main_acct(ticker)
@@ -294,7 +298,7 @@ class Importer(importer.ImporterProtocol):
         # Build transaction entry
         entry = data.Transaction(metadata, date, self.FLAG,
                                  self.get_payee(ot), narration,
-                                 data.EMPTY_SET, data.EMPTY_SET, [])
+                                 self.get_tags(ot), data.EMPTY_SET, [])
         target_acct = self.get_target_acct(ot, ticker)
         if target_acct:
             target_acct = target_acct.format(ticker=ticker)

--- a/beancount_reds_importers/libtransactionbuilder/paycheck.py
+++ b/beancount_reds_importers/libtransactionbuilder/paycheck.py
@@ -116,7 +116,7 @@ class Importer(banking.Importer):
         metadata = data.new_metadata(file.name, 0)
         metadata.update(self.build_metadata(file, metatype='transaction'))
         entry = data.Transaction(metadata, self.paycheck_date(file), self.FLAG,
-                                 None, config['desc'], data.EMPTY_SET, data.EMPTY_SET, [])
+                                 None, config['desc'], self.get_tags(), data.EMPTY_SET, [])
 
         entry = self.build_postings(entry)
         return [entry]


### PR DESCRIPTION
Hi, This provides the importers with a method they can override to create tags.