### PR TITLE
Add buydebt which corresponds to CD for Fidelity

### DIFF
--- a/beancount_reds_importers/libtransactionbuilder/investments.py
+++ b/beancount_reds_importers/libtransactionbuilder/investments.py
@@ -108,6 +108,7 @@ class Importer(importer.ImporterProtocol, transactionbuilder.TransactionBuilder)
             "sellstock":    self.config['cash_account'],
             "buyother":     self.config['cash_account'],
             "sellother":    self.config['cash_account'],
+            "buydebt":      self.config['cash_account'],
             "reinvest":     self.config['dividends'],
             "dividends":    self.config['dividends'],
             "capgainsd_lt": self.config['capgainsd_lt'],
@@ -366,7 +367,7 @@ class Importer(importer.ImporterProtocol, transactionbuilder.TransactionBuilder)
         for ot in self.get_transactions():
             if self.skip_transaction(ot):
                 continue
-            if ot.type in ['buymf', 'sellmf', 'buystock', 'sellstock', 'buyother', 'sellother', 'reinvest']:
+            if ot.type in ['buymf', 'sellmf', 'buystock', 'buydebt', 'sellstock', 'buyother', 'sellother', 'reinvest']:
                 entry = self.generate_trade_entry(ot, file, counter)
             elif ot.type in ['other', 'credit', 'debit', 'transfer', 'dep', 'income',
                              'dividends', 'capgainsd_st', 'capgainsd_lt', 'cash', 'payment', 'check']:


### PR DESCRIPTION
Add `buydebt` as a valid transaction type for investments. It seems to correspond with a CD purchase at Fidelity. There is likely a `selldebt` but since the CDs have some time before they sell (and I moved them over to Vanguard lol) I didn't want to add the `selldebt` transaction type on a hunch.

I noticed other importers have tests but not Fidelity, so I did not add tests. Let me know if you'd like me to copy/paste the Vanguard tests to Fidelity and then add this to the test harness.
