### PR TITLE
Regenerate some extracted unit test data that changed with 75a2d33

### DIFF
--- a/beancount_reds_importers/importers/ally/tests/transactions.qfx.extract
+++ b/beancount_reds_importers/importers/ally/tests/transactions.qfx.extract
@@ -5,4 +5,4 @@
 2019-01-09 * "Check 23400"
   Assets:Banks:Checking  -1000 USD
 
-2019-08-30 balance Assets:Banks:Checking                           150.65 USD
+2019-09-02 balance Assets:Banks:Checking                           150.65 USD

--- a/beancount_reds_importers/importers/capitalonebank/tests/360Checking.qfx.extract
+++ b/beancount_reds_importers/importers/capitalonebank/tests/360Checking.qfx.extract
@@ -11,4 +11,4 @@
 2023-02-28 * "Monthly Interest Paid" ""
   Assets:Banks:CapitalOne  0.01 USD
 
-2023-03-07 balance Assets:Banks:CapitalOne                         4321.98 USD
+2023-03-09 balance Assets:Banks:CapitalOne                         4321.98 USD

--- a/beancount_reds_importers/importers/schwab/schwab_csv_balances.py
+++ b/beancount_reds_importers/importers/schwab/schwab_csv_balances.py
@@ -35,7 +35,7 @@ class Importer(investments.Importer, csv_multitable_reader.Importer):
 
         # fixup currencies
         def remove_non_numeric(x):
-            return re.sub("[^0-9\.]", "", x)  # noqa: W605
+            return re.sub(r'[^0-9\.]', "", x)  # noqa: W605
         currencies = ['unit_price']
         for i in currencies:
             rdr = rdr.convert(i, remove_non_numeric)

--- a/beancount_reds_importers/importers/schwab/schwab_csv_positions.py
+++ b/beancount_reds_importers/importers/schwab/schwab_csv_positions.py
@@ -36,7 +36,7 @@ class Importer(investments.Importer, csvreader.Importer):
 
         # fixup currencies
         def remove_non_numeric(x):
-            return re.sub("[^0-9\.]", "", x)  # noqa: W605
+            return re.sub(r'[^0-9\.]', "", x)  # noqa: W605
         currencies = ['unit_price']
         for i in currencies:
             rdr = rdr.convert(i, remove_non_numeric)

--- a/beancount_reds_importers/importers/vanguard/tests/OfxDownload-401k.qfx.extract
+++ b/beancount_reds_importers/importers/vanguard/tests/OfxDownload-401k.qfx.extract
@@ -18,6 +18,6 @@
 2023-03-07 * "Investment Expense" "[V7743] Vanguard Target Retirement 2050 Trust"
   Assets:Vanguard:401k:Pretax:V7743  -0.000349 V7743
 
-2023-05-25 balance Assets:Vanguard:401k:V7743                      113.718 V7743
-
 2023-05-26 price V7743                              117.71 USD
+
+2023-05-27 balance Assets:Vanguard:401k:V7743                      113.718 V7743

--- a/beancount_reds_importers/libreader/csvreader.py
+++ b/beancount_reds_importers/libreader/csvreader.py
@@ -107,7 +107,7 @@ class Importer(reader.Reader, importer.ImporterProtocol):
 
         # fixup currencies
         def remove_non_numeric(x):
-            return re.sub("[^0-9\.-]", "", str(x).strip())  # noqa: W605
+            return re.sub(r'[^0-9\.-]', "", str(x).strip())  # noqa: W605
         currencies = getattr(self, 'currency_fields', []) + ['unit_price', 'fees', 'total', 'amount', 'balance']
         for i in currencies:
             if i in rdr.header():

--- a/beancount_reds_importers/libreader/tests/balance_assertion_date/ofx_date/transactions.qfx.extract
+++ b/beancount_reds_importers/libreader/tests/balance_assertion_date/ofx_date/transactions.qfx.extract
@@ -5,4 +5,4 @@
 2019-01-09 * "Check 23400"
   Assets:Banks:Checking  -1000 USD
 
-2019-09-01 balance Assets:Banks:Checking                           150.65 USD
+2019-09-02 balance Assets:Banks:Checking                           150.65 USD


### PR DESCRIPTION
It looks like 75a2d33 changed the way some dates are generated. This PR runs `pytest --generate` to update those `.extracted` files with the newly generated dates.

This also fixes one small warning in `csvreader.py` when generating the tests:

```================================================================================================== warnings summary ===================================================================================================
beancount_reds_importers/libreader/csvreader.py:110
  /Users/pharkas/code/beancount_reds_importers/beancount_reds_importers/libreader/csvreader.py:110: DeprecationWarning: invalid escape sequence '\.'
    return re.sub("[^0-9\.-]", "", str(x).strip())  # noqa: W605

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

I added an `r` in front of the pattern string to get rid of this warning. I also made a similar change everywhere else in the project that `\.` was used in a pattern.