### PR TITLE
feat: add importer for Alliant Federal Credit Union

### DIFF
--- a/beancount_reds_importers/importers/alliant/__init__.py
+++ b/beancount_reds_importers/importers/alliant/__init__.py
@@ -1,0 +1,14 @@
+"""Alliant Federal Credit Union ofx importer for beancount."""
+
+from beancount_reds_importers.libreader import ofxreader
+from beancount_reds_importers.libtransactionbuilder import banking
+
+
+class Importer(banking.Importer, ofxreader.Importer):
+    IMPORTER_NAME = 'Alliant Credit Union'
+
+    def custom_init(self):
+        if not self.custom_init_run:
+            self.max_rounding_error = 0.04
+            self.filename_pattern_def = '.*alliant'
+            self.custom_init_run = True


### PR DESCRIPTION
This adds a (trivial) implementation for the Alliant Federal Credit Union, the 8th largest credit union in the United States (by total assets under management).