### PR TITLE
feat: switch to ruff for linting

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -27,13 +27,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
+        python -m pip install -e .[dev] -r requirements.txt
+    - name: Lint with ruff
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 . --count --max-complexity=14 --max-line-length=127 --show-source --statistics
+        ruff check . --statistics
     # - name: Test with pytest
     #   run: |
     #     pytest

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,1 @@
+line-length = 127

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,11 @@ setup(
     license='GPL-3.0',
     packages=find_packages(),
     include_package_data=True,
+    extras_require={
+        'dev': [
+            'ruff',
+        ]
+    },
     install_requires=[
         'Click >= 7.0',
         'beancount >= 2.3.5',


### PR DESCRIPTION
This will greatly increase the speed of the linting; it's setup to be 1:1 compatible with flake8 at the moment.  We have the option to also require formatting checks here, but for the moment, it sticks only to linting.

This is 100% premature optimization -- I think the flake8 tests take like 2s right now -- but since I'm making a [dev] extras _anyway_ for my work in #89... might as well.