### PR TITLE
Only print table header if there are actually accounts that need updates

### DIFF
--- a/beancount_reds_importers/util/needs_update.py
+++ b/beancount_reds_importers/util/needs_update.py
@@ -166,7 +166,8 @@ def accounts_needing_updates(beancount_file, recency, sort_by_date, all_accounts
         for acc, bal in d.items()
         if ((datetime.now().date() - d[acc].date).days > recency)
     }
-    pretty_print_table(need_updates, sort_by_date)
+    if need_updates:
+        pretty_print_table(need_updates, sort_by_date)
 
     # If there are accounts with zero balance entries, print them
     accs_no_bal = accounts_with_no_balance_entries(entries, closes, last_balance)


### PR DESCRIPTION
The needs-update function prints the main table header "Last Updated .... Account" even if there isn't anything that needs to be updated. However, the "Accounts without balance entries" table header only gets printed if there is something that needs to be displayed.

This very small change removes the main table header if there are no accounts that need to be updated. Admittedly this is possibly a personal preference: do you want to see the empty table header but no accounts to reassure you that nothing needs to be updated? Or would you prefer to see the command exit silently (somewhat in keeping with other unix commands)? It doesn't seem worth adding a command-line option for this behaviour so I've just made it the default.