### PR TITLE
feat: genericpdfpaycheck automatically replace periods in header

### DIFF
--- a/beancount_reds_importers/importers/genericpdfpaycheck/__init__.py
+++ b/beancount_reds_importers/importers/genericpdfpaycheck/__init__.py
@@ -55,7 +55,7 @@ class Importer(paycheck.Importer, pdfreader.Importer):
             if label in self.header_map:
                 return self.header_map[header]
 
-            return label.lower().replace(" ", "_")
+            return label.lower().replace(" ", "_").replace(".", "_")
 
         for section, table in self.alltables.items():
             # rename columns


### PR DESCRIPTION
automatically substitute for periods to fix  ValueError: Type names and field names must be valid identifiers