### PR TITLE
build: update gh scripts

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,22 +20,26 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      #with:
+        # Optional: specify uv version
+        #version: "0.7.6"
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .[dev] -r requirements.txt
+        uv sync --all-extras --dev
     - name: Lint with ruff
       run: |
-        ruff check . --statistics
+        uv run ruff check . --statistics
     - name: Test with pytest
       run: |
-        pytest
+        uv run pytest
     - name: Check formatting is applied
       run: |
-        ruff format --check
-        isort --profile black --check .
+        uv run ruff format --check
+        uv run isort --profile black --check .

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -13,19 +13,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        uv sync --all-extras --dev
     - name: Build and publish
       env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        UV_PUBLISH_TOKEN: ${{ secrets.PYPI_PASSWORD }}
+        # UV_PUBLISH_URL
       run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        uv build
+        uv publish


### PR DESCRIPTION
My attempt at updating the GH actions. The tests fail due to missing dependency that are listed in pyproject.toml but not requirements.txt.