### PR TITLE
fix: broken example with updated smart_importer

### DIFF
--- a/beancount_reds_importers/example/_config-smart.py
+++ b/beancount_reds_importers/example/_config-smart.py
@@ -5,7 +5,7 @@ import sys
 from os import path
 
 import beangulp
-from smart_importer import PredictPostings, apply_hooks
+from smart_importer import PredictPostings
 
 sys.path.insert(0, path.join(path.dirname(__file__)))
 
@@ -15,17 +15,16 @@ from beancount_reds_importers.importers import ally
 CONFIG = [
     # Banks and credit cards
     # --------------------------------------------------------------------------------------
-    apply_hooks(
-        ally.Importer(
-            {
-                "account_number": "23456",
-                "main_account": "Assets:Banks:Checking",
-            }
-        ),
-        [PredictPostings()],
-    ),
+    ally.Importer(
+        {
+            "account_number": "23456",
+            "main_account": "Assets:Banks:Checking",
+        }
+    )
 ]
 
+HOOKS = [PredictPostings().hook]
+
 if __name__ == "__main__":
-    ingest = beangulp.Ingest(CONFIG)
+    ingest = beangulp.Ingest(CONFIG, HOOKS)
     ingest()


### PR DESCRIPTION
Example is currently broken if the latest smart_importer is installed. Breaking changes imported from v1.0 via https://github.com/beancount/smart_importer/pull/142. Also take beangulp example as references https://github.com/beancount/beangulp/blob/c5e8188bd186a1c77bb5835b252f2f07d41dd85b/examples/import.py#L73

Before
<img width="989" height="598" alt="image" src="https://github.com/user-attachments/assets/01962498-b46f-497e-97a6-d6cc4401796f" />

After
<img width="785" height="488" alt="image" src="https://github.com/user-attachments/assets/041d367c-3344-4d63-9b17-db19fa76a7d0" />

