### PR TITLE
Add option to use "None" booking method for inventories

### DIFF
--- a/beancount_reds_importers/libtransactionbuilder/common.py
+++ b/beancount_reds_importers/libtransactionbuilder/common.py
@@ -81,12 +81,12 @@ def create_simple_posting_with_cost_or_price(
         number = D(number)
     units = Amount(number, currency)
 
-    if not (price_number or cost_number):
+    if not (price_number or cost_number or costspec):
         if price_cost_both_zero_handler:
             price_cost_both_zero_handler(entry, ot)
         else:
             print(
-                "WARNING: Either price ({}) or cost ({}) must be specified ({})".format(
+                "WARNING: Either price ({}) or cost ({}) or costspec must be specified ({})".format(
                     price_number, cost_number, entry
                 )
             )


### PR DESCRIPTION
This PR allows imports to use a "None" booking method, which is preferable for retirement accounts. See the "No Booking" section discussing this: https://beancount.github.io/docs/how_inventories_work.html

This PR likely needs tests and such, but wanted to put it out there for feedback before investing deeper into the approach