### PR TITLE
No more lot todos

### DIFF
--- a/beancount_reds_importers/libtransactionbuilder/investments.py
+++ b/beancount_reds_importers/libtransactionbuilder/investments.py
@@ -269,10 +269,6 @@ class Importer(BGImporter, transactionbuilder.TransactionBuilder):
         # special cases
         if "sell" in ot.type:
             units = -1 * abs(ot.units)
-            if not is_money_market:
-                metadata["todo"] = (
-                    "TODO: this entry is incomplete until lots are selected (bean-doctor context <filename> <lineno>)"  # noqa: E501
-                )
         if ot.type in [
             "reinvest"
         ]:  # dividends are booked to commodity_leaf. Eg: Income:Dividends:HOOLI


### PR DESCRIPTION
This TODO is not accurate and leads to noise in the beancount files. Lots only need to be selected if a user wants to manually select lots, which is an infrequent case. Automatic lot selection `{}` is fine for the majority of cases