### PR TITLE
Fix settlement fund handling for multiple money market funds

### DIFF
--- a/beancount_reds_importers/libtransactionbuilder/investments.py
+++ b/beancount_reds_importers/libtransactionbuilder/investments.py
@@ -94,6 +94,10 @@ class Importer(BGImporter, transactionbuilder.TransactionBuilder):
             }
             self.set_config_variables(config_subst_vars)
             self.money_market_funds = self.config["fund_info"]["money_market"]
+            self.settlement_fund = self.config["fund_info"].get(
+                "settlement_fund",
+                self.money_market_funds[0] if self.money_market_funds else None,
+            )
             self.fund_data = self.config["fund_info"][
                 "fund_data"
             ]  # [(ticker, id, long_name), ...]
@@ -514,7 +518,7 @@ class Importer(BGImporter, transactionbuilder.TransactionBuilder):
                 None,
             )
             new_entries.append(balance_entry)
-            if ticker in self.money_market_funds:
+            if ticker == self.settlement_fund:
                 settlement_fund_balance = pos.units
 
             # extract price info if available


### PR DESCRIPTION
This code in libtransactionbuilder.investments:
```python
        for pos in self.get_balance_positions():
            ...
            if ticker in self.money_market_funds:
                settlement_fund_balance = pos.units
```
is clearly suspect as it is assigning that value in a loop based on the arbitrary order of the import data. There may be multiple money market funds (it is a list after all), but only one will be the settlement fund. If this isn't handled correctly than the cash balance assertion will be wrong.

With this change the investments importer allows multiple money market funds without assuming they all may be potential settlement funds. fund_info now allows setting an explicit settlement_fund ticker, or it defaults to the first listed money_market ticker as the settlement fund. Hopefully this way it won't break anything.