### PR TITLE
feat: parse OFX security list to auto populate fund data

### DIFF
--- a/beancount_reds_importers/libtransactionbuilder/investments.py
+++ b/beancount_reds_importers/libtransactionbuilder/investments.py
@@ -100,6 +100,18 @@ class Importer(BGImporter, transactionbuilder.TransactionBuilder):
             self.funds_by_id = {i: (ticker, desc) for ticker, i, desc in self.fund_data}
             self.funds_by_ticker = {ticker: (ticker, desc) for ticker, _, desc in self.fund_data}
 
+            # Augment fund_info from OFX SECLIST if available; config-provided entries take precedence
+            try:
+                for sec in self.ofx.security_list or []:
+                    uid = getattr(sec, "uniqueid", None)
+                    ticker = getattr(sec, "ticker", None)
+                    name = getattr(sec, "name", "")
+                    if uid and ticker:
+                        self.funds_by_id.setdefault(uid, (ticker, name))
+                        self.funds_by_ticker.setdefault(ticker, (ticker, name))
+            except AttributeError:
+                pass
+
             # Most ofx/csv files refer to funds by id (cusip/isin etc.) Some use tickers instead
             self.funds_db = getattr(self, getattr(self, "funds_db_txt", "funds_by_id"))
             self.build_account_map()

--- a/beancount_reds_importers/libtransactionbuilder/tests/seclist_fund_info/no_seclist.qfx
+++ b/beancount_reds_importers/libtransactionbuilder/tests/seclist_fund_info/no_seclist.qfx
@@ -1,0 +1,99 @@
+OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:USASCII
+CHARSET:1252
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:NONE
+
+<OFX>
+  <SIGNONMSGSRSV1>
+    <SONRS>
+      <STATUS>
+        <CODE>0
+        <SEVERITY>INFO
+      </STATUS>
+      <DTSERVER>20260316150323[-5:EST]
+      <LANGUAGE>ENG
+    </SONRS>
+  </SIGNONMSGSRSV1>
+  <INVSTMTMSGSRSV1>
+    <INVSTMTTRNRS>
+      <TRNUID>0
+      <STATUS>
+        <CODE>0
+        <SEVERITY>INFO
+      </STATUS>
+      <INVSTMTRS>
+        <DTASOF>20260316160000.000[-5:EST]
+        <CURDEF>USD
+        <INVACCTFROM>
+          <BROKERID>vanguard.com
+          <ACCTID>444555
+        </INVACCTFROM>
+        <INVTRANLIST>
+          <DTSTART>20260101160000.000[-5:EST]
+          <DTEND>20260316150323.000[-5:EST]
+          <BUYMF>
+            <INVBUY>
+              <INVTRAN>
+                <FITID>TEST001
+                <DTTRADE>20260316160000.000[-5:EST]
+                <DTSETTLE>20260316160000.000[-5:EST]
+                <MEMO>Price as of date based on closing price
+              </INVTRAN>
+              <SECID>
+                <UNIQUEID>92202E862
+                <UNIQUEIDTYPE>CUSIP
+              </SECID>
+              <UNITS>10.0
+              <UNITPRICE>58.85
+              <TOTAL>-588.50
+              <SUBACCTSEC>CASH
+              <SUBACCTFUND>OTHER
+              <INV401KSOURCE>PRETAX
+            </INVBUY>
+            <BUYTYPE>BUY
+          </BUYMF>
+        </INVTRANLIST>
+        <INVPOSLIST>
+          <POSMF>
+            <INVPOS>
+              <SECID>
+                <UNIQUEID>92202E862
+                <UNIQUEIDTYPE>CUSIP
+              </SECID>
+              <HELDINACCT>OTHER
+              <POSTYPE>LONG
+              <UNITS>10.0
+              <UNITPRICE>58.85
+              <MKTVAL>588.50
+              <DTPRICEASOF>20260316160000.000[-5:EST]
+              <MEMO>Price as of date based on closing price
+              <INV401KSOURCE>OTHERNONVEST
+            </INVPOS>
+            <REINVDIV>Y
+            <REINVCG>Y
+          </POSMF>
+        </INVPOSLIST>
+        <INV401K>
+          <EMPLOYERNAME>TEST 401(K) PLAN
+          <CURRENTVESTPCT>100.0
+        </INV401K>
+        <INV401KBAL>
+          <CASHBAL>0.0
+          <PRETAX>0.0
+          <AFTERTAX>0.0
+          <MATCH>0.0
+          <PROFITSHARING>0.0
+          <ROLLOVER>0.0
+          <OTHERVEST>0.0
+          <OTHERNONVEST>0.0
+          <TOTAL>0.0
+        </INV401KBAL>
+      </INVSTMTRS>
+    </INVSTMTTRNRS>
+  </INVSTMTMSGSRSV1>
+</OFX>

--- a/beancount_reds_importers/libtransactionbuilder/tests/seclist_fund_info/no_ticker.qfx
+++ b/beancount_reds_importers/libtransactionbuilder/tests/seclist_fund_info/no_ticker.qfx
@@ -1,0 +1,117 @@
+OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:USASCII
+CHARSET:1252
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:NONE
+
+<OFX>
+  <SIGNONMSGSRSV1>
+    <SONRS>
+      <STATUS>
+        <CODE>0
+        <SEVERITY>INFO
+      </STATUS>
+      <DTSERVER>20260316150323[-5:EST]
+      <LANGUAGE>ENG
+    </SONRS>
+  </SIGNONMSGSRSV1>
+  <INVSTMTMSGSRSV1>
+    <INVSTMTTRNRS>
+      <TRNUID>0
+      <STATUS>
+        <CODE>0
+        <SEVERITY>INFO
+      </STATUS>
+      <INVSTMTRS>
+        <DTASOF>20260316160000.000[-5:EST]
+        <CURDEF>USD
+        <INVACCTFROM>
+          <BROKERID>vanguard.com
+          <ACCTID>444555
+        </INVACCTFROM>
+        <INVTRANLIST>
+          <DTSTART>20260101160000.000[-5:EST]
+          <DTEND>20260316150323.000[-5:EST]
+          <BUYMF>
+            <INVBUY>
+              <INVTRAN>
+                <FITID>TEST001
+                <DTTRADE>20260316160000.000[-5:EST]
+                <DTSETTLE>20260316160000.000[-5:EST]
+                <MEMO>Price as of date based on closing price
+              </INVTRAN>
+              <SECID>
+                <UNIQUEID>92202E862
+                <UNIQUEIDTYPE>CUSIP
+              </SECID>
+              <UNITS>10.0
+              <UNITPRICE>58.85
+              <TOTAL>-588.50
+              <SUBACCTSEC>CASH
+              <SUBACCTFUND>OTHER
+              <INV401KSOURCE>PRETAX
+            </INVBUY>
+            <BUYTYPE>BUY
+          </BUYMF>
+        </INVTRANLIST>
+        <INVPOSLIST>
+          <POSMF>
+            <INVPOS>
+              <SECID>
+                <UNIQUEID>92202E862
+                <UNIQUEIDTYPE>CUSIP
+              </SECID>
+              <HELDINACCT>OTHER
+              <POSTYPE>LONG
+              <UNITS>10.0
+              <UNITPRICE>58.85
+              <MKTVAL>588.50
+              <DTPRICEASOF>20260316160000.000[-5:EST]
+              <MEMO>Price as of date based on closing price
+              <INV401KSOURCE>OTHERNONVEST
+            </INVPOS>
+            <REINVDIV>Y
+            <REINVCG>Y
+          </POSMF>
+        </INVPOSLIST>
+        <INV401K>
+          <EMPLOYERNAME>TEST 401(K) PLAN
+          <CURRENTVESTPCT>100.0
+        </INV401K>
+        <INV401KBAL>
+          <CASHBAL>0.0
+          <PRETAX>0.0
+          <AFTERTAX>0.0
+          <MATCH>0.0
+          <PROFITSHARING>0.0
+          <ROLLOVER>0.0
+          <OTHERVEST>0.0
+          <OTHERNONVEST>0.0
+          <TOTAL>0.0
+        </INV401KBAL>
+      </INVSTMTRS>
+    </INVSTMTTRNRS>
+  </INVSTMTMSGSRSV1>
+  <SECLISTMSGSRSV1>
+    <SECLIST>
+      <MFINFO>
+        <SECINFO>
+          <SECID>
+            <UNIQUEID>92202E862
+            <UNIQUEIDTYPE>CUSIP
+          </SECID>
+          <SECNAME>VANGUARD TARGET RETIREMENT 2050 INVESTOR CL
+          <UNITPRICE>58.85
+          <DTASOF>20260316160000.000[-5:EST]
+          <MEMO>Price as of date based on closing price
+        </SECINFO>
+        <MFTYPE>OPENEND
+        <YIELD>0.0
+      </MFINFO>
+    </SECLIST>
+  </SECLISTMSGSRSV1>
+</OFX>

--- a/beancount_reds_importers/libtransactionbuilder/tests/seclist_fund_info/test_seclist_fund_info.py
+++ b/beancount_reds_importers/libtransactionbuilder/tests/seclist_fund_info/test_seclist_fund_info.py
@@ -1,0 +1,116 @@
+"""Unit tests for SECLIST-based fund_info augmentation in investments.Importer.
+
+The initialize() method in investments.Importer populates funds_by_id and
+funds_by_ticker from two sources, with config taking precedence:
+  1. fund_info['fund_data'] in the importer config  (highest precedence)
+  2. The SECLIST section of the OFX file            (fills in the rest)
+
+Static fixture files in this directory cover the key scenarios:
+  with_ticker.qfx  - SECLIST entry has both UNIQUEID and TICKER
+  no_ticker.qfx    - SECLIST entry has UNIQUEID but no TICKER
+  no_seclist.qfx   - OFX file has no SECLISTMSGSRSV1 block at all
+"""
+
+from os import path
+
+from beancount_reds_importers.importers import vanguard
+
+TESTDIR = path.dirname(__file__)
+
+WITH_TICKER = path.join(TESTDIR, "with_ticker.qfx")
+NO_TICKER = path.join(TESTDIR, "no_ticker.qfx")
+NO_SECLIST = path.join(TESTDIR, "no_seclist.qfx")
+
+CUSIP = "92202E862"
+TICKER = "VFIFX"
+SECNAME = "VANGUARD TARGET RETIREMENT 2050 INVESTOR CL"
+
+
+def make_importer(fund_data=None, money_market=None):
+    return vanguard.Importer(
+        {
+            "account_number": "444555",
+            "main_account": "Assets:Vanguard:401k:{source401k}:{ticker}",
+            "cash_account": "Assets:Vanguard:401k:Cash",
+            "dividends": "Income:Dividends:Vanguard:401k:{source401k}:{ticker}",
+            "interest": "Income:Interest:Vanguard:401k:{source401k}:{ticker}",
+            "cg": "Income:CapitalGains:401k:{source401k}:{ticker}",
+            "capgainsd_lt": "Income:CapitalGains:Long:Vanguard:401k:{source401k}:{ticker}",
+            "capgainsd_st": "Income:CapitalGains:Short:Vanguard:401k:{source401k}:{ticker}",
+            "fees": "Expenses:Fees:Vanguard:401k",
+            "invexpense": "Expenses:Expenses:Vanguard:401k",
+            "rounding_error": "Equity:Rounding-Errors:Imports",
+            "emit_filing_account_metadata": False,
+            "fund_info": {
+                "fund_data": fund_data or [],
+                "money_market": money_market or [],
+            },
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# SECLIST populates fund_info when fund_data is empty
+# ---------------------------------------------------------------------------
+
+
+def test_seclist_populates_funds_by_id():
+    importer = make_importer()
+    importer.initialize(WITH_TICKER)
+    assert importer.funds_by_id[CUSIP] == (TICKER, SECNAME)
+
+
+def test_seclist_populates_funds_by_ticker():
+    importer = make_importer()
+    importer.initialize(WITH_TICKER)
+    assert importer.funds_by_ticker[TICKER] == (TICKER, SECNAME)
+
+
+# ---------------------------------------------------------------------------
+# Config-provided entries take precedence over SECLIST
+# ---------------------------------------------------------------------------
+
+
+def test_config_entry_not_overwritten_by_seclist_in_funds_by_id():
+    importer = make_importer(fund_data=[("MY_TICKER", CUSIP, "My Fund Name")])
+    importer.initialize(WITH_TICKER)
+    assert importer.funds_by_id[CUSIP] == ("MY_TICKER", "My Fund Name")
+
+
+def test_config_entry_not_overwritten_by_seclist_in_funds_by_ticker():
+    importer = make_importer(fund_data=[("MY_TICKER", CUSIP, "My Fund Name")])
+    importer.initialize(WITH_TICKER)
+    assert importer.funds_by_ticker["MY_TICKER"] == ("MY_TICKER", "My Fund Name")
+
+
+# ---------------------------------------------------------------------------
+# SECLIST entries without a <TICKER> tag are silently skipped
+# ---------------------------------------------------------------------------
+
+
+def test_seclist_entry_without_ticker_not_added_to_funds_by_id():
+    importer = make_importer()
+    importer.initialize(NO_TICKER)
+    assert CUSIP not in importer.funds_by_id
+
+
+def test_seclist_entry_without_ticker_not_added_to_funds_by_ticker():
+    importer = make_importer()
+    importer.initialize(NO_TICKER)
+    assert TICKER not in importer.funds_by_ticker
+
+
+# ---------------------------------------------------------------------------
+# OFX files with no SECLIST block are handled without error
+# ---------------------------------------------------------------------------
+
+
+def test_no_seclist_does_not_raise():
+    importer = make_importer(fund_data=[(TICKER, CUSIP, "Vanguard 2050")])
+    importer.initialize(NO_SECLIST)  # must not raise
+
+
+def test_no_seclist_config_entries_still_present():
+    importer = make_importer(fund_data=[(TICKER, CUSIP, "Vanguard 2050")])
+    importer.initialize(NO_SECLIST)
+    assert importer.funds_by_id[CUSIP] == (TICKER, "Vanguard 2050")

--- a/beancount_reds_importers/libtransactionbuilder/tests/seclist_fund_info/with_ticker.qfx
+++ b/beancount_reds_importers/libtransactionbuilder/tests/seclist_fund_info/with_ticker.qfx
@@ -1,0 +1,118 @@
+OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:USASCII
+CHARSET:1252
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:NONE
+
+<OFX>
+  <SIGNONMSGSRSV1>
+    <SONRS>
+      <STATUS>
+        <CODE>0
+        <SEVERITY>INFO
+      </STATUS>
+      <DTSERVER>20260316150323[-5:EST]
+      <LANGUAGE>ENG
+    </SONRS>
+  </SIGNONMSGSRSV1>
+  <INVSTMTMSGSRSV1>
+    <INVSTMTTRNRS>
+      <TRNUID>0
+      <STATUS>
+        <CODE>0
+        <SEVERITY>INFO
+      </STATUS>
+      <INVSTMTRS>
+        <DTASOF>20260316160000.000[-5:EST]
+        <CURDEF>USD
+        <INVACCTFROM>
+          <BROKERID>vanguard.com
+          <ACCTID>444555
+        </INVACCTFROM>
+        <INVTRANLIST>
+          <DTSTART>20260101160000.000[-5:EST]
+          <DTEND>20260316150323.000[-5:EST]
+          <BUYMF>
+            <INVBUY>
+              <INVTRAN>
+                <FITID>TEST001
+                <DTTRADE>20260316160000.000[-5:EST]
+                <DTSETTLE>20260316160000.000[-5:EST]
+                <MEMO>Price as of date based on closing price
+              </INVTRAN>
+              <SECID>
+                <UNIQUEID>92202E862
+                <UNIQUEIDTYPE>CUSIP
+              </SECID>
+              <UNITS>10.0
+              <UNITPRICE>58.85
+              <TOTAL>-588.50
+              <SUBACCTSEC>CASH
+              <SUBACCTFUND>OTHER
+              <INV401KSOURCE>PRETAX
+            </INVBUY>
+            <BUYTYPE>BUY
+          </BUYMF>
+        </INVTRANLIST>
+        <INVPOSLIST>
+          <POSMF>
+            <INVPOS>
+              <SECID>
+                <UNIQUEID>92202E862
+                <UNIQUEIDTYPE>CUSIP
+              </SECID>
+              <HELDINACCT>OTHER
+              <POSTYPE>LONG
+              <UNITS>10.0
+              <UNITPRICE>58.85
+              <MKTVAL>588.50
+              <DTPRICEASOF>20260316160000.000[-5:EST]
+              <MEMO>Price as of date based on closing price
+              <INV401KSOURCE>OTHERNONVEST
+            </INVPOS>
+            <REINVDIV>Y
+            <REINVCG>Y
+          </POSMF>
+        </INVPOSLIST>
+        <INV401K>
+          <EMPLOYERNAME>TEST 401(K) PLAN
+          <CURRENTVESTPCT>100.0
+        </INV401K>
+        <INV401KBAL>
+          <CASHBAL>0.0
+          <PRETAX>0.0
+          <AFTERTAX>0.0
+          <MATCH>0.0
+          <PROFITSHARING>0.0
+          <ROLLOVER>0.0
+          <OTHERVEST>0.0
+          <OTHERNONVEST>0.0
+          <TOTAL>0.0
+        </INV401KBAL>
+      </INVSTMTRS>
+    </INVSTMTTRNRS>
+  </INVSTMTMSGSRSV1>
+  <SECLISTMSGSRSV1>
+    <SECLIST>
+      <MFINFO>
+        <SECINFO>
+          <SECID>
+            <UNIQUEID>92202E862
+            <UNIQUEIDTYPE>CUSIP
+          </SECID>
+          <SECNAME>VANGUARD TARGET RETIREMENT 2050 INVESTOR CL
+          <TICKER>VFIFX
+          <UNITPRICE>58.85
+          <DTASOF>20260316160000.000[-5:EST]
+          <MEMO>Price as of date based on closing price
+        </SECINFO>
+        <MFTYPE>OPENEND
+        <YIELD>0.0
+      </MFINFO>
+    </SECLIST>
+  </SECLISTMSGSRSV1>
+</OFX>


### PR DESCRIPTION
Many OFX files contain a `<SECLIST>` section that groups together CUSIPs, tickers, and long form security names. This is the same info that users currently manually populate into `fund_data` fields on importer configs.

This change reads security lists from OFX files when they're present, and uses their info to automatically populate `fund_data`. Any explicitly provided fund data from the user will still override the automatically populated data.

This should remove an element of regular manual interaction when importing OFX files for accounts that often interact with new securities.